### PR TITLE
Modified FA2 & NFT APIs to use Taquito ContractMethod

### DIFF
--- a/packages/fa2-interfaces/src/tezos-api.ts
+++ b/packages/fa2-interfaces/src/tezos-api.ts
@@ -1,10 +1,22 @@
 import { tzip12, Tzip12Module } from '@taquito/tzip12';
-import { Tzip12Contract, address } from './type-aliases';
-import { TezosToolkit } from '@taquito/taquito';
 
-export interface TezosApi {
-  at: (contractAddress: address) => Promise<ContractApi>;
-  useLambdaView: (lambdaView: address) => TezosApi;
+import {
+  ContractMethod,
+  ContractProvider,
+  TezosToolkit
+} from '@taquito/taquito';
+
+import { Tzip12Contract, address } from './type-aliases';
+
+/**
+ * ContractCall describes a call to a contract that can be either run or
+ * add to an existing batch. The run method does Tquito send(), and then wait
+ * for conformation.
+ * 
+ * @returns a hash number of a confirmed operation
+ */
+export interface ContractCall {
+  run: () => Promise<number>;
 }
 
 export interface ContractApi {
@@ -13,6 +25,19 @@ export interface ContractApi {
     createApi: (contract: Tzip12Contract, lambdaView?: address) => O
   ) => I & O;
 }
+
+export interface TezosApi {
+  at: (contractAddress: address) => Promise<ContractApi>;
+  useLambdaView: (lambdaView: address) => TezosApi;
+}
+
+export const contractCall = (cm: ContractMethod<ContractProvider>): ContractCall => ({
+  run: async () => {
+    const op = await cm.send();
+    const hash = await op.confirmation();
+    return hash;
+  }
+});
 
 const contractApi = (
   contract: Tzip12Contract,

--- a/packages/fa2-interfaces/src/tezos-api.ts
+++ b/packages/fa2-interfaces/src/tezos-api.ts
@@ -11,10 +11,12 @@ import { Tzip12Contract, address } from './type-aliases';
 /**
  * A type-safe API to a contract at specific address that, by default,
  * has only one method "with". By chaining "with" it can be extended
- * to include multiple interfaces, like FA2, NFT, Admin etc., 
- * like this: 
+ * to include multiple interfaces, like FA2, NFT, Admin etc.,
+ * like this:
  * 
+ * ```typescript
  * contract.with(Fa2).with(Nft)
+ * ```
  */
 export interface ContractApi {
   /**
@@ -22,8 +24,8 @@ export interface ContractApi {
    *
    * @typeParam I current contract API
    * @typeParam O additional API to be composed with the current one
-   * 
-   * @param createApi a constructor function that should return 
+   *
+   * @param createApi a constructor function that should return
    * an object (a record of functions) to extend the current API with
    */
   with: <I extends ContractApi, O>(
@@ -101,10 +103,14 @@ export const tezosApi = (tzt: TezosToolkit, lambdaView?: address): TezosApi => {
  * Run and confirms a Taquito ContractMethod
  * @param cm - a Taquito contract method
  * @returns  a hash of a confirmed method
+ * 
+ * Usage example:* 
+ * ```typescript
+ * await fa2.runMethod(fa2Contract.transferTokens(txs));
+ * ```
  */
 export const runMethod = async (cm: ContractMethod<ContractProvider>) => {
   const op = await cm.send();
   const hash = await op.confirmation();
   return hash;
 };
-

--- a/packages/fa2-interfaces/src/tezos-api.ts
+++ b/packages/fa2-interfaces/src/tezos-api.ts
@@ -13,7 +13,7 @@ import { Tzip12Contract, address } from './type-aliases';
  * has only one method "with". By chaining "with" it can be extended
  * to include multiple interfaces, like FA2, NFT, Admin etc.,
  * like this:
- * 
+ *
  * ```typescript
  * contract.with(Fa2).with(Nft)
  * ```
@@ -101,16 +101,16 @@ export const tezosApi = (tzt: TezosToolkit, lambdaView?: address): TezosApi => {
 
 /**
  * Run and confirms a Taquito ContractMethod
- * @param cm - a Taquito contract method
- * @returns  a hash of a confirmed method
- * 
- * Usage example:* 
+ * @param cm - a Taquito ContractMethod
+ * @returns  Taquito TransactionOperation
+ *
+ * Usage example:*
  * ```typescript
- * await fa2.runMethod(fa2Contract.transferTokens(txs));
+ * const op: TransactionOperation = await fa2.runMethod(fa2Contract.transferTokens(txs));
  * ```
  */
 export const runMethod = async (cm: ContractMethod<ContractProvider>) => {
   const op = await cm.send();
-  const hash = await op.confirmation();
-  return hash;
+  await op.confirmation();
+  return op;
 };

--- a/packages/nft-tutorial/src/contracts.ts
+++ b/packages/nft-tutorial/src/contracts.ts
@@ -98,7 +98,9 @@ export async function mintNfts(
   const nftContract = (await fa2.tezosApi(tz).at(collectionAddress)).with(Nft);
 
   console.log(kleur.yellow('minting tokens...'));
-  await nftContract.mintTokens([{ owner: ownerAddress, tokens }]).run();
+  await fa2.runMethod(
+    nftContract.mintTokens([{ owner: ownerAddress, tokens }])
+  );
   console.log(kleur.green('tokens minted'));
 }
 
@@ -119,7 +121,9 @@ export async function mintNftsFromFile(
   const nftContract = (await fa2.tezosApi(tz).at(collectionAddress)).with(Nft);
 
   console.log(kleur.yellow('minting tokens...'));
-  await nftContract.mintTokens([{ owner: ownerAddress, tokens }]).run();
+  await fa2.runMethod(
+    nftContract.mintTokens([{ owner: ownerAddress, tokens }])
+  );
   console.log(kleur.green('tokens minted'));
 }
 
@@ -297,7 +301,7 @@ export async function transfer(
   const fa2Contract = (await fa2.tezosApi(tz).at(nftAddress)).with(Fa2);
 
   console.log(kleur.yellow('transferring tokens...'));
-  await fa2Contract.transferTokens(txs).run();
+  await fa2.runMethod(fa2Contract.transferTokens(txs));
   console.log(kleur.green('tokens transferred'));
 }
 
@@ -355,7 +359,7 @@ export async function updateOperators(
   const fa2Contract = (await fa2.tezosApi(tz).at(nftAddress)).with(Fa2);
 
   console.log(kleur.yellow('updating operators...'));
-  await fa2Contract.updateOperators(resolvedAdd, resolvedRemove).run();
+  await fa2.runMethod(fa2Contract.updateOperators(resolvedAdd, resolvedRemove));
   console.log(kleur.green('updated operators'));
 }
 

--- a/packages/nft-tutorial/src/contracts.ts
+++ b/packages/nft-tutorial/src/contracts.ts
@@ -37,7 +37,7 @@ export function createToolkitFromSigner(
 ): TezosToolkit {
   const toolkit = createToolkitWithoutSigner(config);
   toolkit.setProvider({
-    signer,
+    signer
   });
   return toolkit;
 }
@@ -96,7 +96,10 @@ export async function mintNfts(
   const ownerAddress = await tz.signer.publicKeyHash();
 
   const nftContract = (await fa2.tezosApi(tz).at(collectionAddress)).with(Nft);
-  await nftContract.mintTokens([{ owner: ownerAddress, tokens }]);
+
+  console.log(kleur.yellow('minting tokens...'));
+  await nftContract.mintTokens([{ owner: ownerAddress, tokens }]).run();
+  console.log(kleur.green('tokens minted'));
 }
 
 export async function mintNftsFromFile(
@@ -114,7 +117,10 @@ export async function mintNftsFromFile(
   const ownerAddress = await tz.signer.publicKeyHash();
 
   const nftContract = (await fa2.tezosApi(tz).at(collectionAddress)).with(Nft);
-  await nftContract.mintTokens([{ owner: ownerAddress, tokens }]);
+
+  console.log(kleur.yellow('minting tokens...'));
+  await nftContract.mintTokens([{ owner: ownerAddress, tokens }]).run();
+  console.log(kleur.green('tokens minted'));
 }
 
 async function loadTokensFromFile(
@@ -140,9 +146,12 @@ export async function mintFreeze(
   const config = loadUserConfig();
   const tz = await createToolkit(owner, config);
   const collectionAddress = await resolveAlias2Address(collection, config);
-  
-  const nftContract = (await fa2.tezosApi(tz).at(collectionAddress)).with(Nft)
+
+  const nftContract = (await fa2.tezosApi(tz).at(collectionAddress)).with(Nft);
+
+  console.log(kleur.yellow('freezing nft collection...'));
   await nftContract.freezeCollection();
+  console.log(kleur.green('nft collection frozen'));
 }
 
 export function parseTokens(
@@ -286,7 +295,10 @@ export async function transfer(
   const tz = await createToolkit(signer, config);
 
   const fa2Contract = (await fa2.tezosApi(tz).at(nftAddress)).with(Fa2);
-  await fa2Contract.transferTokens(txs);
+
+  console.log(kleur.yellow('transferring tokens...'));
+  await fa2Contract.transferTokens(txs).run();
+  console.log(kleur.green('tokens transferred'));
 }
 
 async function resolveTxAddresses(
@@ -341,7 +353,10 @@ export async function updateOperators(
   const nftAddress = await resolveAlias2Address(contract, config);
 
   const fa2Contract = (await fa2.tezosApi(tz).at(nftAddress)).with(Fa2);
-  await fa2Contract.updateOperators(resolvedAdd, resolvedRemove);
+
+  console.log(kleur.yellow('updating operators...'));
+  await fa2Contract.updateOperators(resolvedAdd, resolvedRemove).run();
+  console.log(kleur.green('updated operators'));
 }
 
 async function resolveOperators(

--- a/packages/nft-tutorial/src/contracts.ts
+++ b/packages/nft-tutorial/src/contracts.ts
@@ -154,7 +154,7 @@ export async function mintFreeze(
   const nftContract = (await fa2.tezosApi(tz).at(collectionAddress)).with(Nft);
 
   console.log(kleur.yellow('freezing nft collection...'));
-  await nftContract.freezeCollection();
+  fa2.runMethod(await nftContract.freezeCollection());
   console.log(kleur.green('nft collection frozen'));
 }
 

--- a/packages/nft-tutorial/src/nft-interface.ts
+++ b/packages/nft-tutorial/src/nft-interface.ts
@@ -1,9 +1,9 @@
-import kleur from 'kleur';
-
 import {
   Tzip12Contract,
   address,
-  TokenMetadataInternal
+  TokenMetadataInternal,
+  contractCall,
+  ContractCall
 } from '@oxheadalpha/fa2-interfaces';
 
 export interface MintParam {
@@ -12,28 +12,11 @@ export interface MintParam {
 }
 
 export interface NftContract {
-  mintTokens: (tokens: MintParam[]) => Promise<void>;
-  freezeCollection: () => Promise<void>;
+  mintTokens: (tokens: MintParam[]) => ContractCall;
+  freezeCollection: () => ContractCall;
 }
 
-export const Nft = (
-  contract: Tzip12Contract,
-): NftContract => ({
-  mintTokens: async tokens => {
-    console.log(kleur.yellow('minting tokens...'));
-
-    const op = await contract.methods.mint(tokens).send();
-    await op.confirmation();
-
-    console.log(kleur.green('tokens minted'));
-  },
-
-  freezeCollection: async () => {
-    console.log(kleur.yellow('freezing nft collection...'));
-
-    const op = await contract.methods.mint_freeze().send();
-    await op.confirmation();
-
-    console.log(kleur.green('nft collection frozen'));
-  }
+export const Nft = (contract: Tzip12Contract): NftContract => ({
+  mintTokens: tokens => contractCall(contract.methods.mint(tokens)),
+  freezeCollection: () => contractCall(contract.methods.mint_freeze())
 });

--- a/packages/nft-tutorial/src/nft-interface.ts
+++ b/packages/nft-tutorial/src/nft-interface.ts
@@ -1,9 +1,12 @@
 import {
+  ContractMethod,
+  ContractProvider
+} from '@taquito/taquito';
+
+import {
   Tzip12Contract,
   address,
-  TokenMetadataInternal,
-  contractCall,
-  ContractCall
+  TokenMetadataInternal
 } from '@oxheadalpha/fa2-interfaces';
 
 export interface MintParam {
@@ -12,11 +15,11 @@ export interface MintParam {
 }
 
 export interface NftContract {
-  mintTokens: (tokens: MintParam[]) => ContractCall;
-  freezeCollection: () => ContractCall;
+  mintTokens: (tokens: MintParam[]) => ContractMethod<ContractProvider>;
+  freezeCollection: () => ContractMethod<ContractProvider>;
 }
 
 export const Nft = (contract: Tzip12Contract): NftContract => ({
-  mintTokens: tokens => contractCall(contract.methods.mint(tokens)),
-  freezeCollection: () => contractCall(contract.methods.mint_freeze())
+  mintTokens: tokens => contract.methods.mint(tokens),
+  freezeCollection: () => contract.methods.mint_freeze()
 });


### PR DESCRIPTION
Modified FA2 & NFT APIs to use Taquito ContractMethod which allows to batch them into Taquito batches.
Also changed some comments in tezos-api.