### PR TITLE
nat as BigNumber | number

### DIFF
--- a/packages/fa2-interfaces/src/fa2-interface.ts
+++ b/packages/fa2-interfaces/src/fa2-interface.ts
@@ -1,3 +1,4 @@
+import { BigNumber } from 'bignumber.js';
 import {
   ContractMethod,
   ContractProvider,
@@ -175,9 +176,11 @@ export const Fa2 = (
     hasNftTokens: async requests => {
       const responses = await self.queryBalances(requests);
 
+      const one = new BigNumber(1);
+      const zero = new BigNumber(0);
       const results = responses.map(r => {
-        if (r.balance.eq(1)) return true;
-        else if (r.balance.eq(0)) return false;
+        if (one.eq(r.balance)) return true;
+        else if (zero.eq(r.balance)) return false;
         else throw new Error(`Invalid NFT balance ${r.balance}`);
       });
 

--- a/packages/fa2-interfaces/src/type-aliases.ts
+++ b/packages/fa2-interfaces/src/type-aliases.ts
@@ -26,5 +26,5 @@ export type Tzip12Contract = Contract & {
 }
 
 export type address = string;
-export type nat = BigNumber;
+export type nat = BigNumber | number;
 export type bytes = string;

--- a/packages/tznft/__tests__/collection-mint.test.ts
+++ b/packages/tznft/__tests__/collection-mint.test.ts
@@ -1,5 +1,4 @@
 import * as kleur from 'kleur';
-import { BigNumber } from 'bignumber.js';
 import { address, Fa2, runMethod, runBatch } from '@oxheadalpha/fa2-interfaces';
 import { Nft } from '../src/nft-interface';
 
@@ -38,8 +37,8 @@ describe('NFT Collection Minting Tests', () => {
     expect(meta.map(t => t.token_id)).toEqual([1, 2]);
 
     const ownership = await fa2.hasNftTokens([
-      { owner: bobAddress, token_id: new BigNumber(1) },
-      { owner: bobAddress, token_id: new BigNumber(1) }
+      { owner: bobAddress, token_id: 1 },
+      { owner: bobAddress, token_id: 2 }
     ]);
     expect(ownership).toEqual([true, true]);
   });

--- a/packages/tznft/__tests__/collection-transfer.test.ts
+++ b/packages/tznft/__tests__/collection-transfer.test.ts
@@ -4,7 +4,6 @@ import {
   address,
   Fa2,
   runMethod,
-  runBatch,
   Transfer,
   Fa2Contract
 } from '@oxheadalpha/fa2-interfaces';
@@ -41,7 +40,7 @@ describe('FA2 Token Transfer Tests', () => {
   ): Transfer {
     return {
       from_,
-      txs: [{ to_, token_id: new BigNumber(tokenId), amount: new BigNumber(1) }]
+      txs: [{ to_, token_id: tokenId, amount: 1 }]
     };
   }
 
@@ -50,8 +49,8 @@ describe('FA2 Token Transfer Tests', () => {
     owner: address
   ): Promise<boolean[]> =>
     fa2.hasNftTokens([
-      { owner, token_id: new BigNumber(1) },
-      { owner, token_id: new BigNumber(2) }
+      { owner, token_id: 1 },
+      { owner, token_id: 2 }
     ]);
 
   test('transfer', async () => {
@@ -94,7 +93,7 @@ describe('FA2 Token Transfer Tests', () => {
         [
           {
             owner: bobAddress,
-            token_id: new BigNumber(1),
+            token_id: 1,
             operator: aliceAddress
           }
         ],

--- a/packages/tznft/src/contracts.ts
+++ b/packages/tznft/src/contracts.ts
@@ -137,7 +137,7 @@ async function loadTokensFromFile(
     })
     .map(line => {
       let [tokenId, metadataUri] = line.split(',').map(s => s.trim());
-      return createTokenMetadata(tokenId, metadataUri);
+      return createTokenMetadata(new BigNumber(tokenId), metadataUri);
     });
 }
 
@@ -161,7 +161,7 @@ export function parseTokens(
   tokens: fa2.TokenMetadataInternal[]
 ): fa2.TokenMetadataInternal[] {
   const [id, tokenMetadataUri] = descriptor.split(',').map(p => p.trim());
-  const token = createTokenMetadata(id, tokenMetadataUri);
+  const token = createTokenMetadata(new BigNumber(id), tokenMetadataUri);
   token.token_info.set('', char2Bytes(tokenMetadataUri));
   return [token].concat(tokens);
 }

--- a/packages/tznft/src/contracts.ts
+++ b/packages/tznft/src/contracts.ts
@@ -238,7 +238,7 @@ export function parseTransfers(
       {
         to_,
         token_id: new BigNumber(token_id),
-        amount: new BigNumber(1)
+        amount: 1
       }
     ]
   };

--- a/packages/tznft/src/nft-interface.ts
+++ b/packages/tznft/src/nft-interface.ts
@@ -9,6 +9,7 @@ import { char2Bytes } from '@taquito/utils';
 import {
   Tzip12Contract,
   address,
+  nat,
   TokenMetadataInternal,
   bytes
 } from '@oxheadalpha/fa2-interfaces';
@@ -52,11 +53,11 @@ export function createNftStorage(owner: string, metaJson: string) {
 }
 
 export function createTokenMetadata(
-  tokenId: string | number,
+  tokenId: nat,
   tokenMetadataUri: string
 ): TokenMetadataInternal {
   const m: TokenMetadataInternal = {
-    token_id: new BigNumber(tokenId),
+    token_id: tokenId,
     token_info: new MichelsonMap()
   };
   m.token_info.set('', char2Bytes(tokenMetadataUri));


### PR DESCRIPTION
Taquito accepts either `number` or `BigNumber` type when Michelson `nat` type is required.
Update FA2 interfaces to accept both `nat` representations.